### PR TITLE
feat: enabling publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
           overwrite-repository: true
           repository-url: https://test.pypi.org/legacy/
           token: ${{ secrets.TEST_PYPI_TOKEN }}
-#  build-and-publish:
-#    needs: build-and-publish-test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: maticardenas/.github/workflows/publish@main
-#        with:
-#          token: ${{ secrets.PYPI_TOKEN }}
+  build-and-publish:
+    needs: build-and-publish-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: maticardenas/.github/workflows/publish@main
+        with:
+          token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
After renaming package, enabling `publish` stage for actual `PyPi` repository.